### PR TITLE
remove duplication of 'jazzmin' app in INSTALLED_APPS ( Fixes #21 )

### DIFF
--- a/ra/project_template/project_template/project_name/settings.py
+++ b/ra/project_template/project_template/project_name/settings.py
@@ -47,8 +47,7 @@ INSTALLED_APPS = [
     'ra.activity',
     'ra.reporting',
     'slick_reporting',
-    'jazzmin',
-    'django.contrib.admin', # comes at the end because the theme is replaced
+    'django.contrib.admin',  # comes at the end because the theme is replaced
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Fixes #21 

Hi, Mr.Ramiz. I hope you're well.
This is a fix for the duplication of the `jazzmin` app which raised errors when we attempt to migrate or run the server.
